### PR TITLE
Fixed right operators in slate.js

### DIFF
--- a/slate/slate.js
+++ b/slate/slate.js
@@ -40,21 +40,21 @@ var leftTwoThird = S.operation('move', {
 var rightThird = S.operation('move', {
   'x'     : 'screenOriginX+screenSizeX/1.5',
   'y'     : 'screenOriginY',
-  'width' : '(screenSizeX+1)/3',
+  'width' : 'ceiling(screenSizeX/3)',
   'height': 'screenSizeY'
 });
 
 var rightHalf = S.operation('move', {
   'x'     : 'screenOriginX+screenSizeX/2',
   'y'     : 'screenOriginY',
-  'width' : '(screenSizeX+1)/2',
+  'width' : 'ceiling(screenSizeX/2)',
   'height': 'screenSizeY'
 });
 
 var rightTwoThird = S.operation('move', {
   'x'     : 'screenOriginX+screenSizeX/3',
   'y'     : 'screenOriginY',
-  'width' : '(screenSizeX+1)/1.5',
+  'width' : 'ceiling(screenSizeX/1.5)',
   'height': 'screenSizeY'
 });
 

--- a/slate/slate.js
+++ b/slate/slate.js
@@ -40,21 +40,21 @@ var leftTwoThird = S.operation('move', {
 var rightThird = S.operation('move', {
   'x'     : 'screenOriginX+screenSizeX/1.5',
   'y'     : 'screenOriginY',
-  'width' : 'screenSizeX/3',
+  'width' : '(screenSizeX+1)/3',
   'height': 'screenSizeY'
 });
 
 var rightHalf = S.operation('move', {
   'x'     : 'screenOriginX+screenSizeX/2',
   'y'     : 'screenOriginY',
-  'width' : 'screenSizeX/2',
+  'width' : '(screenSizeX+1)/2',
   'height': 'screenSizeY'
 });
 
 var rightTwoThird = S.operation('move', {
   'x'     : 'screenOriginX+screenSizeX/3',
   'y'     : 'screenOriginY',
-  'width' : 'screenSizeX/1.5',
+  'width' : '(screenSizeX+1)/1.5',
   'height': 'screenSizeY'
 });
 


### PR DESCRIPTION
Corrected off by one pixel error for right operators due by integer truncation when calculating the width. This resulted to inconsistencies between the final x coordinate and width, where one was taking the ceiling and the other taking the floor.